### PR TITLE
Fixed package import

### DIFF
--- a/jsfl/Exporter.jsfl
+++ b/jsfl/Exporter.jsfl
@@ -693,7 +693,7 @@ p.writeDartMain = function() {
 p.writeDartIndex = function() {
 	Log.time("write index " + this.dartFilePath);
 
-	str = 'import \'../lib/$DOCNAME.dart\';\n'
+	str = 'import \'package:$DOCNAME/$DOCNAME.dart\';\n'
 		+ '\n'
 		+ 'void main() {\n'
 		+ '  new '+this.docSymbolName+'();\n'


### PR DESCRIPTION
The import with the relative path doesn't work in Dartium any longer. I changed the import to a package import, but i didn't compile the Toolkit to check if it is actually working. I also don't have a Flash licence to test it out :( 
